### PR TITLE
feature/confirm product return

### DIFF
--- a/app/controller/OrderController.go
+++ b/app/controller/OrderController.go
@@ -99,3 +99,27 @@ func ConfirmProductRetrieval(w http.ResponseWriter, r *http.Request) {
 	}
 	json.NewEncoder(w).Encode(response)
 }
+
+func ConfirmProductReturn(w http.ResponseWriter, r *http.Request) {
+	golog.Info("/api/orders/return")
+
+	db := helper.OpenDatabaseConnection()
+	defer db.Close()
+
+	var confirmProductReturnRequest ConfirmProductReturnRequest
+	var order model.Order
+	var response WebResponse
+
+	json.NewDecoder(r.Body).Decode(&confirmProductReturnRequest)
+
+	if db.Where("id = ?", confirmProductReturnRequest.OrderId).Find(&order).RecordNotFound() {
+		golog.Warn("Order with ID " + string(confirmProductReturnRequest.OrderId) + " not found!")
+		response = ERROR(model.ORDER_NOT_FOUND)
+	} else {
+		db.Where("id = ?", confirmProductReturnRequest.OrderId).Find(&order)
+		db.Model(&order).Update("order_status", model.DONE)
+		response = OK(nil)
+		golog.Info("Confirm product return succeed")
+	}
+	json.NewEncoder(w).Encode(response)
+}

--- a/app/helper/DatabaseConnectionHelper.go
+++ b/app/helper/DatabaseConnectionHelper.go
@@ -16,8 +16,6 @@ func OpenDatabaseConnection() *gorm.DB {
 			"sslmode=disable")
 	if err != nil {
 		golog.Warn("Error connecting to DB : ", err)
-	} else {
-		golog.Info("Success connecting to DB!")
 	}
 	return db
 }

--- a/app/model/request/ConfirmProductReturnRequest.go
+++ b/app/model/request/ConfirmProductReturnRequest.go
@@ -1,0 +1,5 @@
+package request
+
+type ConfirmProductReturnRequest struct {
+	OrderId uint
+}

--- a/app/route/Route.go
+++ b/app/route/Route.go
@@ -13,6 +13,7 @@ func GetAllRoutes() *mux.Router {
 
 	routes.HandleFunc("/orders", controller.PlaceOrder).Methods("POST")
 	routes.HandleFunc("/orders/reception", controller.ConfirmProductRetrieval).Methods("POST")
+	routes.HandleFunc("/orders/return", controller.ConfirmProductReturn).Methods("POST")
 
 	return routes
 }


### PR DESCRIPTION
- Access `/api/orders/return` for confirming product's return
- Request body is the same as in API documentation
- **NO UNIT TESTS**

**DETAILS**
[ADD] endpoint `/api/orders/return` for confirming product's return
[REMOVE] log for success connecting to DB in `DatabaseConnectionHelper.go` file